### PR TITLE
Display Errors with reading the Absolute Encoders

### DIFF
--- a/swervelib/SwerveDrive.java
+++ b/swervelib/SwerveDrive.java
@@ -901,6 +901,8 @@ public class SwerveDrive
               "Module[" + module.configuration.name + "] Relative Encoder", module.getRelativePosition());
           SmartDashboard.putNumber(
               "Module[" + module.configuration.name + "] Absolute Encoder", module.getAbsolutePosition());
+          SmartDashboard.putNumber(
+                "Module[" + module.configuration.name + "] Absolute Encoder Read Issue", module.getAbsoluteEncoderReadIssue());
         }
         if (SwerveDriveTelemetry.verbosity.ordinal() >= TelemetryVerbosity.HIGH.ordinal())
         {

--- a/swervelib/SwerveModule.java
+++ b/swervelib/SwerveModule.java
@@ -66,6 +66,11 @@ public class SwerveModule
   private boolean                synchronizeEncoderQueued = false;
 
   /**
+   * Absolute Encoder Read Issue Dectected. 
+   */
+  public boolean                  absoluteEncoderReadIssue = false;
+
+  /**
    * Construct the swerve module and initialize the swerve module motors and absolute encoder.
    *
    * @param moduleNumber        Module number for kinematics.
@@ -298,13 +303,16 @@ public class SwerveModule
     double angle;
     if (absoluteEncoder != null)
     {
+      absoluteEncoderReadIssue = false;
       angle = absoluteEncoder.getAbsolutePosition() - angleOffset;
       if (absoluteEncoder.readingError)
       {
+        absoluteEncoderReadIssue = true;
         angle = getRelativePosition();
       }
     } else
     {
+      absoluteEncoderReadIssue = true;
       angle = getRelativePosition();
     }
     angle %= 360;
@@ -386,5 +394,15 @@ public class SwerveModule
   public SwerveModuleConfiguration getConfiguration()
   {
     return configuration;
+  }
+
+  /*
+   * Get if the last Absolute Encoder had a read issue.
+   * 
+   * @return If the last Absolute Encoder had a read issue.
+   */
+  public boolean getAbsoluteEncoderReadIssue()
+  {
+    return absoluteEncoderReadIssue;
   }
 }


### PR DESCRIPTION
YAGSL has automatic failover to the relative encoder from the absolute encoder, but doesn't seem to alert when that happens. This is meant to show that there is an error and show if the problem is intermittent or continuous. My use case for this would be to use logging to record it and play it back with AdvantageScope to review the match to see if there is any errors that may need to be repaired. 