### PR TITLE
Fix Thrifty Encoder JSON option

### DIFF
--- a/swervelib/parser/json/DeviceJson.java
+++ b/swervelib/parser/json/DeviceJson.java
@@ -80,6 +80,7 @@ public class DeviceJson
       case "dutycycle":
         return new PWMDutyCycleEncoderSwerve(id);
       case "thrifty":
+        return new AnalogAbsoluteEncoderSwerve(id);
       case "analog":
         return new AnalogAbsoluteEncoderSwerve(id);
       case "cancoder":


### PR DESCRIPTION
Hello!

Wonderful project, and thank you very much for all your hard work! My team has been working to get swerve up and running with SDS Mk4 modules, REV Neos, a NavX2-MXP, and Thrifty Absolute Magnetic Encoders. Everything has worked quite well, except that we noticed that we weren't reading any data from the Thrifty encoders. After digging into the API code, we noticed that while`AnalogAbsoluteEncoderSwerve.java` implemented the Thrifty encoder, the switch statement in `DeviceJson.java` wouldn't instantiate an `AnalogAbsoluteEncoderSwerve` since there was nothing in the case for `thrifty`. 

This PR instantiates an `AnalogAbsoluteEncoderSwerve` in the case for `thrifty` in order to fix this. 

We have tested this on our swerve base, and the code we used can be found [in our repository](https://github.com/frc937/swerving-learning-box). It works to correctly read the values from the thrifty encoders.