### PR TITLE
Make the individual modules public so we can do telemetry.

### DIFF
--- a/swervelib/SwerveDrive.java
+++ b/swervelib/SwerveDrive.java
@@ -62,7 +62,7 @@ public class SwerveDrive
   /**
    * Swerve modules.
    */
-  private final SwerveModule[]           swerveModules;
+  public final SwerveModule[]            swerveModules;
   /**
    * WPILib {@link Notifier} to keep odometry up to date.
    */


### PR DESCRIPTION
See issue #41.

This makes the modules public, so we can do 

```
for (var swerveModule : swerveDrive.swerveModules) {
  var which = swerveModule.getConfiguration().name;
  var driveMotor = swerveModule.getDriveMotor();
  var angleMotor = swerveModule.getAngleMotor();
  // ... do something
}
```