### PR TITLE
Use VoltageOut setter to gain FOC suppport.

### DIFF
--- a/swervelib/motors/TalonFXSwerve.java
+++ b/swervelib/motors/TalonFXSwerve.java
@@ -4,6 +4,7 @@ import com.ctre.phoenix6.configs.TalonFXConfiguration;
 import com.ctre.phoenix6.configs.TalonFXConfigurator;
 import com.ctre.phoenix6.controls.MotionMagicVoltage;
 import com.ctre.phoenix6.controls.VelocityVoltage;
+import com.ctre.phoenix6.controls.VoltageOut;
 import com.ctre.phoenix6.hardware.TalonFX;
 import com.ctre.phoenix6.signals.FeedbackSensorSourceValue;
 import com.ctre.phoenix6.signals.NeutralModeValue;
@@ -33,6 +34,10 @@ public class TalonFXSwerve extends SwerveMotor
    * Velocity voltage setter for controlling drive motor.
    */
   private final VelocityVoltage    m_velocityVoltageSetter = new VelocityVoltage(0);
+  /**
+   * Voltage setter for controlling the motor.
+   */
+  private final VoltageOut m_voltageOutSetter = new VoltageOut(0);
   /**
    * Wait time for status frames to show up.
    */
@@ -367,7 +372,7 @@ public class TalonFXSwerve extends SwerveMotor
   @Override
   public void setVoltage(double voltage)
   {
-    motor.setVoltage(voltage);
+    motor.setControl(m_voltageOutSetter.withOutput(voltage));
   }
 
   /**


### PR DESCRIPTION
Should not impact non phoenix pro users per [this post](https://www.chiefdelphi.com/t/yet-another-generic-swerve-library-yagsl-v1-release/450844/261), but will allow setVoltage commands with TalonFX-based motors to use FOC if available by license.