### PR TITLE
Simplify placeInAppropriate0To360Scope

### DIFF
--- a/swervelib/math/SwerveMath.java
+++ b/swervelib/math/SwerveMath.java
@@ -359,6 +359,9 @@ public class SwerveMath
   /**
    * Put an angle within the 360 deg scope of a reference. For example, given a scope reference of 756 degrees, assumes
    * the full scope is (720-1080), and places an angle of 22 degrees into it, returning 742 deg.
+   * 
+   * A more formal definition: returns the closest angle {@code n} to {@code scopeReference} such that {@code n} is
+   * congruent to {@code newAngle}.
    *
    * @param scopeReference Current Angle (deg)
    * @param newAngle       Target Angle (deg)
@@ -366,34 +369,11 @@ public class SwerveMath
    */
   public static double placeInAppropriate0To360Scope(double scopeReference, double newAngle)
   {
-    double lowerBound;
-    double upperBound;
-    double lowerOffset = scopeReference % 360;
-    if (lowerOffset >= 0)
-    {
-      lowerBound = scopeReference - lowerOffset;
-      upperBound = scopeReference + (360 - lowerOffset);
-    } else
-    {
-      upperBound = scopeReference - lowerOffset;
-      lowerBound = scopeReference - (360 + lowerOffset);
-    }
-    while (newAngle < lowerBound)
-    {
-      newAngle += 360;
-    }
-    while (newAngle > upperBound)
-    {
-      newAngle -= 360;
-    }
-    if (newAngle - scopeReference > 180)
-    {
-      newAngle -= 360;
-    } else if (newAngle - scopeReference < -180)
-    {
-      newAngle += 360;
-    }
-    return newAngle;
+    // Figure out how many revolutions from the angle to the reference
+    double diffRevs = Math.round((scopeReference - newAngle) / 360) * 360;
+
+    // Add that many revolutions
+    return diffRevs + newAngle;
   }
 
   /**


### PR DESCRIPTION
`placeInAppropriate0To360Scope` is a lot more complicated than it needs to be. I simplified it greatly (which also improves its readability) and added a more formal definition to the documentation for clarification.

Aside from the fact that the expected logic is the same as the original function, I performed 100 billion fuzz tests with random angles in a 64-revolution range and my new function does not deviate from the original function except for minuscule differences (less than 10^-12) due to floating point error that arises because the new implementation performs fewer operations, as well as in scenarios with multiple correct outputs (e.g. the original function returns `0` when provided `180.0, 0.0`, while mine returns `360`).

This was also tested in my school's 2024 competition (well I just graduated from there but you get the point) and it worked perfectly there.