### PR TITLE
CalculateMaxAngularVelocity now uses the physical radius of the modules

### DIFF
--- a/swervelib/math/SwerveMath.java
+++ b/swervelib/math/SwerveMath.java
@@ -136,7 +136,7 @@ public class SwerveMath
   public static double calculateMaxAngularVelocity(
       double maxSpeed, double furthestModuleX, double furthestModuleY)
   {
-    return maxSpeed / new Rotation2d(furthestModuleX, furthestModuleY).getRadians();
+    return maxSpeed / Math.hypot(furthestModuleX, furthestModuleY);
   }
 
   /**


### PR DESCRIPTION
When calculating the maxAngularVelocity of the robot a Rotation2d is used. A rotation2d uses a unit circle, which will does not accurately represent the size of the robot.

![image](https://github.com/user-attachments/assets/79cef615-4789-48f2-a4f0-cc4c95c57b0e)

![image](https://github.com/user-attachments/assets/ae370a86-0b86-43ea-91d2-a310e5ec10da)

![image](https://github.com/user-attachments/assets/542f359d-5151-460b-b39c-99ab12e76237)

![image](https://github.com/user-attachments/assets/ae63b7a6-9cbe-4248-b203-0e032a33ad10)

For example, my robot is has modules at (+/- 0.28575m, +/- 0.28575m) and a max velocity of 4.8 m/s (max standard gearing of a MaxSwerve). When using rotation2d we get 6.1 m/s for the max angular velocity:

![image](https://github.com/user-attachments/assets/505699f3-23df-41ab-a318-1521455e1d64)

Using inches instead of meters yields the same result of ~6.1 rad/s (0.28575 -> 11.25 in): 

![image](https://github.com/user-attachments/assets/b23aae74-1f2a-48bf-b587-69c6351e353e)

I replaced this with $w = \frac{v}{r}$ which yields $\frac{4.8}{0.404112} = 11.87789 rad/s$. This number can be mentally double checked by thinking about the distance traveled as the circumference of the circle that swerves make: $C = 2\pi r \rightarrow C = 2.53782336 -> \frac{4.8}{2.5378} = 1.89$ revolutions per second. 

Apologies if I have a misunderstanding for the usage of the unit circle if that was intentional. With this change you may want to update your examples and the tuning webpage to use meters and specify that meters are desired. I would also be happy to make those changes if my push is approved.

![image](https://github.com/user-attachments/assets/2bf31011-6990-4ef4-9a05-7ba89bb70fe8)

![image](https://github.com/user-attachments/assets/5bdbbd30-3af9-4de2-a18c-f45053a7efad)

![image](https://github.com/user-attachments/assets/715c39e7-5c7f-4fb9-a4e6-987462443d92)
