### PR TITLE
fix: don't ignore field-relative ChassisSpeeds

### DIFF
--- a/swervelib/SwerveDrive.java
+++ b/swervelib/SwerveDrive.java
@@ -567,7 +567,7 @@ public class SwerveDrive
 
     if (fieldRelative)
     {
-      ChassisSpeeds.fromFieldRelativeSpeeds(velocity, getOdometryHeading());
+      velocity = ChassisSpeeds.fromFieldRelativeSpeeds(velocity, getOdometryHeading());
     }
     drive(velocity, isOpenLoop, new Translation2d());
   }


### PR DESCRIPTION
In SwerveDrive#drive, the field-relative converted chassis speeds are never used, causing the drive method to always be robot relative, regardless of the fieldRelative argument. @sharp-3260 