### PR TITLE
Update how max angular velocity for a module is calculated.

### DIFF
--- a/swervelib/SwerveModule.java
+++ b/swervelib/SwerveModule.java
@@ -780,7 +780,7 @@ public class SwerveModule
     if (maxAngularVelocity == null)
     {
       maxAngularVelocity = RotationsPerSecond.of(
-          RadiansPerSecond.of(angleMotor.getSimMotor().freeSpeedRadPerSec).in(RotationsPerSecond) *
+          RadiansPerSecond.of(angleMotor.getSimMotor().freeSpeedRadPerSec).in(RotationsPerSecond) /
           configuration.conversionFactors.angle.gearRatio);
     }
     return maxAngularVelocity;


### PR DESCRIPTION
In the getMaxAngularVelocity() method of swerveModule, corrected the calculation to divide by the gear ratio instead of multiplying.